### PR TITLE
84 feat: ComponentCommand `isUserComponent` option

### DIFF
--- a/src/classes/Commands.js
+++ b/src/classes/Commands.js
@@ -306,9 +306,21 @@ class CommandBase {
 
 
 /**
+ * @typedef {BaseConfig} ComponentCommandConfig
+ * @property {boolean} [isUserComponent = true] If true, the component is only available to the user who initiated it. If false, everyone can interact with the component
+ */
+
+/**
  * @extends {CommandBase}
  */
 class ComponentCommand extends CommandBase {
+  constructor (config) {
+    super(config);
+    /**
+     * @property {boolean} global If true, the component is only available to the user who initiated it. If false, everyone can interact with the component
+     */
+    this.isUserComponent = 'isUserComponent' in config ? config.isUserComponent : true;
+  }
 }
 
 

--- a/src/listeners/interaction/interactionCreate.js
+++ b/src/listeners/interaction/interactionCreate.js
@@ -3,8 +3,7 @@ const chalk = require('chalk');
 const { InteractionType } = require('discord.js');
 const {
   checkCommandCanExecute,
-  throttleCommand,
-  hasAccessToComponentCommand
+  throttleCommand
 } = require('../../handlers/commands');
 const { getPermissionLevel } = require('../../handlers/permissions');
 const { titleCase, getRuntime } = require('../../util');
@@ -127,22 +126,6 @@ const runCommand = (client, interaction, activeId, cmdRunTimeStart) => {
   if (!clientCanReply) {
     logger.debug(`Interaction returned - Can't reply to interaction\nCommand: ${data.name}\nServer: ${guild.name}\nChannel: #${channel.name}\nMember: ${member}`);
     return;
-  }
-
-  // Check if the Component Command is meant for the member initiating it
-  if (
-    interaction.isButton()
-   || interaction.isStringSelectMenu()
-   || interaction.isMessageComponent()
-  ) {
-    const componentIsForMember = hasAccessToComponentCommand(interaction);
-    if (!componentIsForMember) {
-      interaction.reply({
-        content: `${emojis.error} ${member}, this message component isn't meant for you.`,
-        ephemeral: true
-      });
-      return;
-    }
   }
 
   // Perform our additional checks


### PR DESCRIPTION
Allows ComponentCommands to be restricted to the interaction user (the component creator, if available) or to be available globally to everyone